### PR TITLE
[FEAT] 회원가입 api 구현

### DIFF
--- a/src/main/java/com/capstone/domain/user/controller/UserController.java
+++ b/src/main/java/com/capstone/domain/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.capstone.domain.user.controller;
+
+import com.capstone.domain.user.dto.request.SignUpRequestDto;
+import com.capstone.domain.user.dto.response.SignUpResponseDto;
+import com.capstone.domain.user.service.UserService;
+import com.capstone.global.common.ApiResponse;
+import com.capstone.global.common.SuccessStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth/users")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserService userService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<ApiResponse<SignUpResponseDto>> signUp(
+      @Valid @RequestBody SignUpRequestDto request
+  ) {
+    SignUpResponseDto response = userService.signUp(request);
+    return ResponseEntity.status(SuccessStatus.CREATED.getHttpStatus())
+        .body(ApiResponse.created(SuccessStatus.CREATED, response));
+  }
+}

--- a/src/main/java/com/capstone/domain/user/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/capstone/domain/user/dto/request/SignUpRequestDto.java
@@ -1,0 +1,21 @@
+package com.capstone.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignUpRequestDto(
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    String password,
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(max = 20, message = "닉네임은 20자 이하로 입력해주세요.")
+    String nickname
+) {
+}

--- a/src/main/java/com/capstone/domain/user/dto/response/SignUpResponseDto.java
+++ b/src/main/java/com/capstone/domain/user/dto/response/SignUpResponseDto.java
@@ -1,0 +1,11 @@
+package com.capstone.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SignUpResponseDto(
+    Long userId,
+    String email,
+    String nickname
+) {
+}

--- a/src/main/java/com/capstone/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/domain/user/entity/User.java
@@ -3,14 +3,13 @@ package com.capstone.domain.user.entity;
 import com.capstone.domain.clover.entity.CloverHistory;
 import com.capstone.domain.journal.entity.Journal;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "users")
@@ -60,5 +59,17 @@ public class User {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.role = Role.USER;
+  }
+
+  public static User create(String email, String password, String nickname) {
+    LocalDateTime now = LocalDateTime.now();
+    return User.builder()
+        .email(email)
+        .password(password)
+        .nickname(nickname)
+        .cloverBalance(0L)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
   }
 }

--- a/src/main/java/com/capstone/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/UserRepository.java
@@ -2,10 +2,16 @@ package com.capstone.domain.user.repository;
 
 
 import com.capstone.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+  boolean existsByEmail(String email);
+
+  boolean existsByNickname(String nickname);
+
+  Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/capstone/domain/user/service/UserService.java
+++ b/src/main/java/com/capstone/domain/user/service/UserService.java
@@ -1,0 +1,53 @@
+package com.capstone.domain.user.service;
+
+import com.capstone.domain.user.dto.request.SignUpRequestDto;
+import com.capstone.domain.user.dto.response.SignUpResponseDto;
+import com.capstone.domain.user.entity.User;
+import com.capstone.domain.user.repository.UserRepository;
+import com.capstone.global.error.BusinessException;
+import com.capstone.global.error.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Transactional
+  public SignUpResponseDto signUp(SignUpRequestDto request) {
+    validateDuplicateEmail(request.email());
+    validateDuplicateNickname(request.nickname());
+
+    User user = User.create(
+        request.email(),
+        passwordEncoder.encode(request.password()),
+        request.nickname()
+    );
+
+    User savedUser = userRepository.save(user);
+
+    return SignUpResponseDto.builder()
+        .userId(savedUser.getId())
+        .email(savedUser.getEmail())
+        .nickname(savedUser.getNickname())
+        .build();
+  }
+
+  private void validateDuplicateEmail(String email) {
+    if (userRepository.existsByEmail(email)) {
+      throw new BusinessException(ErrorStatus.EMAIL_ALREADY_EXISTS);
+    }
+  }
+
+  private void validateDuplicateNickname(String nickname) {
+    if (userRepository.existsByNickname(nickname)) {
+      throw new BusinessException(ErrorStatus.NICKNAME_ALREADY_EXISTS);
+    }
+  }
+}

--- a/src/main/java/com/capstone/domain/user/service/UserService.java
+++ b/src/main/java/com/capstone/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.error.BusinessException;
 import com.capstone.global.error.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,8 +31,18 @@ public class UserService {
         request.nickname()
     );
 
-    User savedUser = userRepository.save(user);
-
+    User savedUser;
+    try {
+      savedUser = userRepository.save(user);
+    } catch (DataIntegrityViolationException e) {
+      if (userRepository.existsByEmail(request.email())) {
+        throw new BusinessException(ErrorStatus.EMAIL_ALREADY_EXISTS);
+      }
+      if (userRepository.existsByNickname(request.nickname())) {
+        throw new BusinessException(ErrorStatus.NICKNAME_ALREADY_EXISTS);
+      }
+      throw e;
+    }
     return SignUpResponseDto.builder()
         .userId(savedUser.getId())
         .email(savedUser.getEmail())

--- a/src/main/java/com/capstone/global/error/ErrorStatus.java
+++ b/src/main/java/com/capstone/global/error/ErrorStatus.java
@@ -29,11 +29,17 @@ public enum ErrorStatus {
    * 403 Forbidden
    */
   FORBIDDEN_USER(40300, HttpStatus.FORBIDDEN, "권한이 없는 요청입니다."),
+
   /**
    * 404 Not Found
    */
   USER_NOT_FOUND(40400, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-  ITEM_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
+
+  /**
+   * 409 Conflict
+   */
+  EMAIL_ALREADY_EXISTS(40900, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+  NICKNAME_ALREADY_EXISTS(40901, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 
   /**
    * 500 Internal Server Error

--- a/src/main/java/com/capstone/global/security/SecurityBeanConfig.java
+++ b/src/main/java/com/capstone/global/security/SecurityBeanConfig.java
@@ -1,0 +1,15 @@
+package com.capstone.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityBeanConfig {
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #11 
- close #13 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원가입 API(POST /api/v1/users/signup)를 구현

- 요청/응답 DTO를 추가하고, 입력값 검증 로직을 적용

- 이메일/닉네임 중복 검사 로직을 추가

- 비밀번호 암호화를 적용한 뒤 사용자 정보를 DB에 저장하도록 구현

- 회원가입 성공/실패 시 공통 응답 포맷(ApiResponse)을 사용하도록 적용

- 중복 회원가입 예외 처리를 위해 관련 ErrorStatus를 추가

## 📸 테스트 증명 (필수)
[회원가입 api 테스트]
<img width="1087" height="808" alt="image" src="https://github.com/user-attachments/assets/82efbe60-1f5f-4d03-b50c-0a3e2a5eaf95" />

[DB]
<img width="1694" height="344" alt="image" src="https://github.com/user-attachments/assets/dc8e537f-167f-4702-b3ce-05dbd8cbff9c" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 사용자 회원가입 기능 추가: 이메일, 비밀번호, 닉네임을 통한 계정 생성 지원
  * 회원가입 입력값 검증: 이메일 형식, 비밀번호 길이(8-20자), 닉네임 길이(20자 이내) 검증
  * 중복 가입 방지: 동일한 이메일 또는 닉네임 사용 시 오류 반환
  * 보안 강화: 비밀번호 암호화 처리 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->