### PR TITLE
[FEAT] RefreshToken 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.11'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.11'
+    id 'io.spring.dependency-management' version '1.1.7'
     id 'com.google.cloud.tools.jib' version '3.5.2'       // Jib 플러그인
 }
 
@@ -9,32 +9,32 @@ group = 'com.capstone'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // jwt
@@ -44,8 +44,24 @@ dependencies {
 
     //.env 자동 로드 라이브러리 추가
     implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+
+    // OpenFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // Swagger (SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
+}
+
+ext {
+    set('springCloudVersion', "2025.0.0")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/capstone/domain/auth/dto/request/AuthRequestDto.java
+++ b/src/main/java/com/capstone/domain/auth/dto/request/AuthRequestDto.java
@@ -1,0 +1,9 @@
+package com.capstone.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthRequestDto (
+  @NotBlank(message = "토큰은 필수입니다.")
+  String token
+) {
+  }

--- a/src/main/java/com/capstone/domain/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/com/capstone/domain/auth/dto/response/AuthResponseDto.java
@@ -1,0 +1,11 @@
+package com.capstone.domain.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AuthResponseDto(  String accessToken,
+                                String refreshToken,
+                                boolean isNewUser,
+                                Long userId
+) {
+}

--- a/src/main/java/com/capstone/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/capstone/domain/auth/entity/RefreshToken.java
@@ -1,5 +1,7 @@
 package com.capstone.domain.auth.entity;
 
+import com.capstone.global.error.BusinessException;
+import com.capstone.global.error.ErrorStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +26,12 @@ public class RefreshToken {
   private Long ttl; // 초 단위
 
   public void updateRefreshToken(String refreshToken, Long ttl) {
+    if (refreshToken == null || refreshToken.isBlank()) {
+      throw new BusinessException(ErrorStatus.INVALID_REFRESH_TOKEN);
+    }
+    if (ttl == null || ttl <= 0) {
+      throw new BusinessException(ErrorStatus.BAD_REQUEST);
+    }
     this.refreshToken = refreshToken;
     this.ttl = ttl;
   }

--- a/src/main/java/com/capstone/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/capstone/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,30 @@
+package com.capstone.domain.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@RedisHash(value = "refreshToken")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+  @Id
+  private Long userId; // Redis Key: refreshToken:{userId}
+
+  private String refreshToken;
+
+  @TimeToLive
+  private Long ttl; // 초 단위
+
+  public void updateRefreshToken(String refreshToken, Long ttl) {
+    this.refreshToken = refreshToken;
+    this.ttl = ttl;
+  }
+}

--- a/src/main/java/com/capstone/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/capstone/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.capstone.domain.auth.repository;
+
+import com.capstone.domain.auth.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/com/capstone/global/config/SwaggerConfig.java
+++ b/src/main/java/com/capstone/global/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.capstone.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  private static final String SECURITY_SCHEME_NAME = "authorization";
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .components(new Components()
+            .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                .name(SECURITY_SCHEME_NAME)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+        .info(new Info()
+            .title("MONINI Server API")
+            .description("MONINI 서비스 API 명세서")
+            .version("1.0.0"));
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #18 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- Redis 기반 RefreshToken 관리 구조 도입

- RefreshToken 엔티티 생성 (@RedisHash, TTL 기반 만료 설정)

- RefreshTokenRepository 구현 (Spring Data Redis 사용)

- 로그인 시 사용자 기준 RefreshToken 저장 및 갱신 로직 추가

- 로그아웃 시 Redis에 저장된 RefreshToken 삭제 로직 구현

- JWT 기반 인증 구조에서 AccessToken / RefreshToken 분리 발급 구조 적용

## 📸 테스트 증명 (필수)

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- RefreshToken을 DB가 아닌 Redis에 저장하여 성능 및 만료 관리 개선

- 사용자(userId) 기준 단일 RefreshToken 관리 구조 적용

- TTL을 활용하여 자동 만료 처리 (세션 관리 효율화)

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 토큰 기반 인증 요청·응답 DTO 및 빌더 지원 추가
  * Refresh token의 저장·갱신 및 자동 만료 처리 기능 추가
  * API 문서(OpenAPI) 및 JWT 보안 설정 추가

* **변경 사항**
  * Spring Cloud BOM 및 Springdoc/OpenFeign 관련 의존성 추가
  * 빌드 파일 포맷 정리 및 의존성 관리 구조 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->