### PR TITLE
[FEAT] 모닝저널 작성 API 구현

### DIFF
--- a/src/main/java/com/capstone/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/capstone/domain/journal/controller/JournalController.java
@@ -1,0 +1,35 @@
+package com.capstone.domain.journal.controller;
+
+import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
+import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
+import com.capstone.domain.journal.service.JournalService;
+import com.capstone.global.common.ApiResponse;
+import com.capstone.global.common.SuccessStatus;
+import com.capstone.global.security.jwt.JwtTokenProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/journals")
+@RequiredArgsConstructor
+public class JournalController {
+
+  private final JournalService journalService;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<JournalCreateResponseDto>> createJournal(
+      @RequestHeader("Authorization") String bearerToken,
+      @Valid @RequestBody JournalCreateRequestDto request
+  ) {
+    String token = bearerToken.replace("Bearer ", "");
+    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+    JournalCreateResponseDto response = journalService.createJournal(userId, request);
+
+    return ResponseEntity.status(SuccessStatus.CREATED.getHttpStatus())
+        .body(ApiResponse.created(SuccessStatus.CREATED, response));
+  }
+}

--- a/src/main/java/com/capstone/domain/journal/dto/request/JournalCreateRequestDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/request/JournalCreateRequestDto.java
@@ -1,0 +1,20 @@
+package com.capstone.domain.journal.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record JournalCreateRequestDto(
+
+    @Size(max = 255, message = "제목은 255자 이하로 입력해주세요.")
+    String title,
+
+    @NotBlank(message = "저널 내용은 필수입니다.")
+    String content,
+
+    @NotNull(message = "저널 작성 날짜는 필수입니다.")
+    LocalDate journalDate
+) {
+}

--- a/src/main/java/com/capstone/domain/journal/dto/response/JournalCreateResponseDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/response/JournalCreateResponseDto.java
@@ -1,0 +1,17 @@
+package com.capstone.domain.journal.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record JournalCreateResponseDto(
+    Long journalId,
+    String title,
+    String content,
+    LocalDate journalDate,
+    LocalDateTime createdAt,
+    Long userId
+) {
+}

--- a/src/main/java/com/capstone/domain/journal/entity/Journal.java
+++ b/src/main/java/com/capstone/domain/journal/entity/Journal.java
@@ -25,16 +25,16 @@ public class Journal {
   @Column(length = 255)
   private String title;
 
-  @Column(columnDefinition = "TEXT")
+  @Column(columnDefinition = "TEXT", nullable = false)
   private String content;
 
-  @Column(name = "journal_date")
+  @Column(name = "journal_date", nullable = false)
   private LocalDate journalDate;
 
-  @Column(name = "created_at")
+  @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 
-  @Column(name = "is_deleted")
+  @Column(name = "is_deleted", nullable = false)
   private Boolean isDeleted;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -56,5 +56,16 @@ public class Journal {
     this.createdAt = createdAt;
     this.isDeleted = isDeleted;
     this.user = user;
+  }
+
+  public static Journal create(String title, String content, LocalDate journalDate, User user) {
+    return Journal.builder()
+        .title(title)
+        .content(content)
+        .journalDate(journalDate)
+        .createdAt(LocalDateTime.now())
+        .isDeleted(false)
+        .user(user)
+        .build();
   }
 }

--- a/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
@@ -1,0 +1,9 @@
+package com.capstone.domain.journal.repository;
+
+import com.capstone.domain.journal.entity.Journal;
+import java.time.LocalDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JournalRepository extends JpaRepository<Journal, Long> {
+  boolean existsByUserIdAndJournalDateAndIsDeletedFalse(Long userId, LocalDate journalDate);
+}

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -1,0 +1,50 @@
+package com.capstone.domain.journal.service;
+
+import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
+import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
+import com.capstone.domain.journal.entity.Journal;
+import com.capstone.domain.journal.repository.JournalRepository;
+import com.capstone.domain.user.entity.User;
+import com.capstone.domain.user.repository.UserRepository;
+import com.capstone.global.error.BusinessException;
+import com.capstone.global.error.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JournalService {
+
+  private final JournalRepository journalRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public JournalCreateResponseDto createJournal(Long userId, JournalCreateRequestDto request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
+
+    if (journalRepository.existsByUserIdAndJournalDateAndIsDeletedFalse(userId, request.journalDate())) {
+      throw new BusinessException(ErrorStatus.JOURNAL_ALREADY_EXISTS_TODAY);
+    }
+
+    Journal journal = Journal.create(
+        request.title(),
+        request.content(),
+        request.journalDate(),
+        user
+    );
+
+    Journal savedJournal = journalRepository.save(journal);
+
+    return JournalCreateResponseDto.builder()
+        .journalId(savedJournal.getId())
+        .title(savedJournal.getTitle())
+        .content(savedJournal.getContent())
+        .journalDate(savedJournal.getJournalDate())
+        .createdAt(savedJournal.getCreatedAt())
+        .userId(user.getId())
+        .build();
+  }
+}

--- a/src/main/java/com/capstone/global/error/ErrorStatus.java
+++ b/src/main/java/com/capstone/global/error/ErrorStatus.java
@@ -15,6 +15,7 @@ public enum ErrorStatus {
   BAD_REQUEST(40000, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
   INVALID_PASSWORD(40001, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
   INVALID_REFRESH_TOKEN(40002, HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
+  JOURNAL_ALREADY_EXISTS_TODAY(40003, HttpStatus.BAD_REQUEST, "오늘은 이미 모닝저널을 작성했습니다."),
 
   /**
    * 401 Unauthorized


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #21

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- Journal 생성 API (POST /api/v1/journals) 추가
- Journal 생성 요청/응답 DTO 추가
- Journal 엔티티 필수값(nullable=false) 및 create() 메서드 추가
- JournalRepository 생성 및 날짜 중복 체크 메서드 추가
- 하루 1회 저널 작성 제한 로직 추가
- JOURNAL_ALREADY_EXISTS_TODAY 예외 코드 추가

## 📸 테스트 증명 (필수)
- journal DB 
<img width="1737" height="240" alt="image" src="https://github.com/user-attachments/assets/f239b47a-c738-4a74-afd4-8d9d8650e562" />


## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 저널 작성 기능 추가: 사용자가 제목, 내용, 작성 날짜를 포함하여 저널 항목을 생성할 수 있습니다.
  * 입력 검증 기능: 제목은 최대 255자, 내용과 날짜는 필수 입력 항목입니다.
  * 중복 방지: 동일한 날짜에 대해 여러 저널 항목 작성을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->