### PR TITLE
[FEAT] 모닝저널 소프트 삭제 API 구현

### DIFF
--- a/src/main/java/com/capstone/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/capstone/domain/journal/controller/JournalController.java
@@ -32,4 +32,18 @@ public class JournalController {
     return ResponseEntity.status(SuccessStatus.CREATED.getHttpStatus())
         .body(ApiResponse.created(SuccessStatus.CREATED, response));
   }
+
+  @DeleteMapping("/{journalId}")
+  public ResponseEntity<ApiResponse<Void>> deleteJournal(
+      @RequestHeader("Authorization") String bearerToken,
+      @PathVariable Long journalId
+  ) {
+    String token = bearerToken.replace("Bearer ", "");
+    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+    journalService.deleteJournal(userId, journalId);
+
+    return ResponseEntity.status(SuccessStatus.OK.getHttpStatus())
+        .body(ApiResponse.success(SuccessStatus.OK));
+  }
 }

--- a/src/main/java/com/capstone/domain/journal/entity/Journal.java
+++ b/src/main/java/com/capstone/domain/journal/entity/Journal.java
@@ -68,4 +68,8 @@ public class Journal {
         .user(user)
         .build();
   }
+
+  public void delete() {
+    this.isDeleted = true;
+  }
 }

--- a/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
@@ -2,8 +2,10 @@ package com.capstone.domain.journal.repository;
 
 import com.capstone.domain.journal.entity.Journal;
 import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JournalRepository extends JpaRepository<Journal, Long> {
   boolean existsByUserIdAndJournalDateAndIsDeletedFalse(Long userId, LocalDate journalDate);
+  Optional<Journal> findByIdAndIsDeletedFalse(Long journalId);
 }

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -47,4 +47,16 @@ public class JournalService {
         .userId(user.getId())
         .build();
   }
+
+  @Transactional
+  public void deleteJournal(Long userId, Long journalId) {
+    Journal journal = journalRepository.findByIdAndIsDeletedFalse(journalId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND));
+
+    if (!journal.getUser().getId().equals(userId)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
+    }
+
+    journal.delete();
+  }
 }

--- a/src/main/java/com/capstone/global/error/ErrorStatus.java
+++ b/src/main/java/com/capstone/global/error/ErrorStatus.java
@@ -39,7 +39,7 @@ public enum ErrorStatus {
   USER_NOT_FOUND(40400, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
   NOT_FOUND_HANDLER(40401, HttpStatus.NOT_FOUND, "존재하지 않는 API 경로입니다."),
   REFRESH_TOKEN_NOT_FOUND(40402, HttpStatus.NOT_FOUND, "저장된 리프레시 토큰이 없습니다."),
-
+  JOURNAL_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "해당 저널을 찾을 수 없습니다."),
   /**
    * 405 Method Not Allowed
    */


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #23

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 저널 삭제 API(DELETE /api/v1/journals/{journalId}) 추가
- 저널 삭제 시 DB에서 제거하지 않고 isDeleted = true로 변경하는 소프트 삭제 적용
- 삭제된 저널은 조회되지 않도록 isDeleted = false 조건 기반 조회 로직 적용
- 본인 저널만 삭제 가능하도록 사용자 권한 검증 로직 추가
- 삭제된 저널 조회 시 예외 처리 (JOURNAL_NOT_FOUND) 추가

## 📸 테스트 증명 (필수)
- 스웨거로 API 테스트
<img width="1167" height="548" alt="image" src="https://github.com/user-attachments/assets/64e86450-af1b-4063-8a7d-76e1ea4b7b01" />

- DB 변경점 확인
<img width="1767" height="431" alt="image" src="https://github.com/user-attachments/assets/aa2c66c9-1ae7-4cac-a27b-d606da490ef7" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [ ] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [ ] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [ ] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [ ] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자가 자신의 저널을 삭제(소프트 삭제)할 수 있는 기능 추가
  * 삭제 요청 시 소유자 검증을 통해 다른 사용자의 저널 삭제 차단

* **오류 처리**
  * 존재하지 않거나 이미 삭제된 저널에 대해 적절한 404 응답 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->