### PR TITLE
[FEAT] 특정 일의 journal 조회 API 구현

### DIFF
--- a/src/main/java/com/capstone/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/capstone/domain/journal/controller/JournalController.java
@@ -2,6 +2,7 @@ package com.capstone.domain.journal.controller;
 
 import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
 import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
+import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
 import com.capstone.domain.journal.service.JournalService;
 import com.capstone.global.common.ApiResponse;
 import com.capstone.global.common.SuccessStatus;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/v1/journals")
@@ -45,5 +47,25 @@ public class JournalController {
 
     return ResponseEntity.status(SuccessStatus.OK.getHttpStatus())
         .body(ApiResponse.success(SuccessStatus.OK));
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<JournalGetResponseDto>> getJournalByDate(
+      @RequestHeader("Authorization") String bearerToken,
+      @RequestParam int year,
+      @RequestParam int month,
+      @RequestParam int day
+  ) {
+    String token = bearerToken.replace("Bearer ", "");
+    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+    LocalDate date = LocalDate.of(year, month, day);
+
+    JournalGetResponseDto response =
+        journalService.getJournalByDate(userId, date);
+
+    return ResponseEntity.ok(
+        ApiResponse.success(SuccessStatus.OK, response)
+    );
   }
 }

--- a/src/main/java/com/capstone/domain/journal/dto/response/JournalGetResponseDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/response/JournalGetResponseDto.java
@@ -1,0 +1,14 @@
+package com.capstone.domain.journal.dto.response;
+
+import lombok.Builder;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record JournalGetResponseDto(
+    Long journalId,
+    String title,
+    String content,
+    LocalDate journalDate,
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JournalRepository extends JpaRepository<Journal, Long> {
   boolean existsByUserIdAndJournalDateAndIsDeletedFalse(Long userId, LocalDate journalDate);
   Optional<Journal> findByIdAndIsDeletedFalse(Long journalId);
+  Optional<Journal> findByUserIdAndJournalDateAndIsDeletedFalse(Long userId, LocalDate journalDate);
 }

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -2,6 +2,7 @@ package com.capstone.domain.journal.service;
 
 import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
 import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
+import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
 import com.capstone.domain.journal.entity.Journal;
 import com.capstone.domain.journal.repository.JournalRepository;
 import com.capstone.domain.user.entity.User;
@@ -11,6 +12,7 @@ import com.capstone.global.error.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -58,5 +60,21 @@ public class JournalService {
     }
 
     journal.delete();
+  }
+
+  @Transactional(readOnly = true)
+  public JournalGetResponseDto getJournalByDate(Long userId, LocalDate date) {
+
+    Journal journal = journalRepository
+        .findByUserIdAndJournalDateAndIsDeletedFalse(userId, date)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND));
+
+    return JournalGetResponseDto.builder()
+        .journalId(journal.getId())
+        .title(journal.getTitle())
+        .content(journal.getContent())
+        .journalDate(journal.getJournalDate())
+        .createdAt(journal.getCreatedAt())
+        .build();
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #24

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 특정 날짜 기준 저널 조회 API(GET /api/v1/journals) 추가
- 사용자 + 날짜 기준으로 저널 조회하도록 Repository 메서드 추가
- 삭제되지 않은 저널만 조회하도록 isDeleted = false 조건 적용
- 조회 결과를 반환하기 위한 Response DTO 추가
- 저널이 존재하지 않을 경우 예외 처리 (JOURNAL_NOT_FOUND) 추가

## 📸 테스트 증명 (필수)
- 스웨거 테스트
<img width="1168" height="705" alt="image" src="https://github.com/user-attachments/assets/f31f1c68-c0c9-4510-999b-7a64eda04274" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 날짜로 일지 항목을 조회할 수 있는 기능이 추가되었습니다. 연도, 월, 일을 지정하여 원하는 날짜의 일지를 검색할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->