### PR TITLE
[FEAT] 무한 스크롤 기반 저널 목록 조회 api 구현

### DIFF
--- a/src/main/java/com/capstone/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/capstone/domain/journal/controller/JournalController.java
@@ -2,6 +2,7 @@ package com.capstone.domain.journal.controller;
 
 import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
 import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
+import com.capstone.domain.journal.dto.response.JournalCursorResponseDto;
 import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
 import com.capstone.domain.journal.service.JournalService;
 import com.capstone.global.common.ApiResponse;
@@ -11,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import java.time.LocalDate;
 
 @RestController
@@ -50,6 +52,22 @@ public class JournalController {
   }
 
   @GetMapping
+  public ResponseEntity<ApiResponse<JournalCursorResponseDto>> getJournalList(
+      @RequestHeader("Authorization") String bearerToken,
+      @RequestParam(required = false) Long cursor,
+      @RequestParam(defaultValue = "10") int size
+  ) {
+    String token = bearerToken.replace("Bearer ", "");
+    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+    JournalCursorResponseDto response = journalService.getJournalList(userId, cursor, size);
+
+    return ResponseEntity.ok(
+        ApiResponse.success(SuccessStatus.OK, response)
+    );
+  }
+
+  @GetMapping("/by-date")
   public ResponseEntity<ApiResponse<JournalGetResponseDto>> getJournalByDate(
       @RequestHeader("Authorization") String bearerToken,
       @RequestParam int year,
@@ -61,8 +79,7 @@ public class JournalController {
 
     LocalDate date = LocalDate.of(year, month, day);
 
-    JournalGetResponseDto response =
-        journalService.getJournalByDate(userId, date);
+    JournalGetResponseDto response = journalService.getJournalByDate(userId, date);
 
     return ResponseEntity.ok(
         ApiResponse.success(SuccessStatus.OK, response)

--- a/src/main/java/com/capstone/domain/journal/dto/response/JournalCursorResponseDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/response/JournalCursorResponseDto.java
@@ -1,0 +1,13 @@
+package com.capstone.domain.journal.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record JournalCursorResponseDto(
+    List<JournalListItemResponseDto> journals,
+    Long nextCursor,
+    boolean hasNext
+) {
+}

--- a/src/main/java/com/capstone/domain/journal/dto/response/JournalListItemResponseDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/response/JournalListItemResponseDto.java
@@ -1,0 +1,16 @@
+package com.capstone.domain.journal.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record JournalListItemResponseDto(
+    Long journalId,
+    String title,
+    String content,
+    LocalDate journalDate,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
@@ -2,11 +2,29 @@ package com.capstone.domain.journal.repository;
 
 import com.capstone.domain.journal.entity.Journal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JournalRepository extends JpaRepository<Journal, Long> {
   boolean existsByUserIdAndJournalDateAndIsDeletedFalse(Long userId, LocalDate journalDate);
   Optional<Journal> findByIdAndIsDeletedFalse(Long journalId);
   Optional<Journal> findByUserIdAndJournalDateAndIsDeletedFalse(Long userId, LocalDate journalDate);
+
+  @Query("""
+      select j
+      from Journal j
+      where j.user.id = :userId
+        and j.isDeleted = false
+        and (:cursor is null or j.id < :cursor)
+      order by j.id desc
+      """)
+  List<Journal> findAllByUserIdWithCursor(
+      @Param("userId") Long userId,
+      @Param("cursor") Long cursor,
+      Pageable pageable
+  );
 }

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -84,7 +84,7 @@ public class JournalService {
 
   @Transactional(readOnly = true)
   public JournalCursorResponseDto getJournalList(Long userId, Long cursor, int size) {
-    int pageSize = Math.min(size, 50);
+    int pageSize = Math.max(1, Math.min(size, 50));
 
     List<Journal> journals = journalRepository.findAllByUserIdWithCursor(
         userId,

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -2,7 +2,9 @@ package com.capstone.domain.journal.service;
 
 import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
 import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
+import com.capstone.domain.journal.dto.response.JournalCursorResponseDto;
 import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
+import com.capstone.domain.journal.dto.response.JournalListItemResponseDto;
 import com.capstone.domain.journal.entity.Journal;
 import com.capstone.domain.journal.repository.JournalRepository;
 import com.capstone.domain.user.entity.User;
@@ -10,9 +12,12 @@ import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.error.BusinessException;
 import com.capstone.global.error.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -64,7 +69,6 @@ public class JournalService {
 
   @Transactional(readOnly = true)
   public JournalGetResponseDto getJournalByDate(Long userId, LocalDate date) {
-
     Journal journal = journalRepository
         .findByUserIdAndJournalDateAndIsDeletedFalse(userId, date)
         .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND));
@@ -75,6 +79,44 @@ public class JournalService {
         .content(journal.getContent())
         .journalDate(journal.getJournalDate())
         .createdAt(journal.getCreatedAt())
+        .build();
+  }
+
+  @Transactional(readOnly = true)
+  public JournalCursorResponseDto getJournalList(Long userId, Long cursor, int size) {
+    int pageSize = Math.min(size, 50);
+
+    List<Journal> journals = journalRepository.findAllByUserIdWithCursor(
+        userId,
+        cursor,
+        PageRequest.of(0, pageSize + 1)
+    );
+
+    boolean hasNext = journals.size() > pageSize;
+
+    if (hasNext) {
+      journals = journals.subList(0, pageSize);
+    }
+
+    List<JournalListItemResponseDto> journalList = journals.stream()
+        .map(journal -> JournalListItemResponseDto.builder()
+            .journalId(journal.getId())
+            .title(journal.getTitle())
+            .content(journal.getContent())
+            .journalDate(journal.getJournalDate())
+            .createdAt(journal.getCreatedAt())
+            .build())
+        .toList();
+
+    Long nextCursor = null;
+    if (hasNext && !journals.isEmpty()) {
+      nextCursor = journals.get(journals.size() - 1).getId();
+    }
+
+    return JournalCursorResponseDto.builder()
+        .journals(journalList)
+        .nextCursor(nextCursor)
+        .hasNext(hasNext)
         .build();
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #25 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 저널 목록 무한 스크롤 조회 API(GET /api/v1/journals) 구현 (cursor 기반 pagination)
- 커서 기반 조회를 위한 Repository 쿼리 추가 (id < cursor 조건)
- JournalCursorResponseDto, JournalListItemResponseDto 응답 구조 추가
- size + 1 조회를 통해 hasNext, nextCursor 계산 로직 구현
- 기존 단건 조회 API를 /api/v1/journals/by-date로 분리하여 역할 명확화

## 📸 테스트 증명 (필수)
<img width="1208" height="914" alt="image" src="https://github.com/user-attachments/assets/70b45e7d-51bc-4d9b-8c5d-d65eedbf0329" />


## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 저널 목록 조회 API 추가 - 커서 기반 페이지네이션으로 사용자의 저널 목록을 효율적으로 조회할 수 있습니다. 페이지 크기를 커스터마이징할 수 있으며 대량의 데이터 로딩 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->