### PR TITLE
[FEAT] AI 저널 기반 코멘트(피드백/응원 메시지) 생성

### DIFF
--- a/src/main/java/com/capstone/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/capstone/domain/journal/controller/JournalController.java
@@ -4,6 +4,7 @@ import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
 import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
 import com.capstone.domain.journal.dto.response.JournalCursorResponseDto;
 import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
+import com.capstone.domain.journal.dto.response.JournalReplyResponseDto;
 import com.capstone.domain.journal.service.JournalService;
 import com.capstone.global.common.ApiResponse;
 import com.capstone.global.common.SuccessStatus;
@@ -80,6 +81,21 @@ public class JournalController {
     LocalDate date = LocalDate.of(year, month, day);
 
     JournalGetResponseDto response = journalService.getJournalByDate(userId, date);
+
+    return ResponseEntity.ok(
+        ApiResponse.success(SuccessStatus.OK, response)
+    );
+  }
+
+  @PostMapping("/{journalId}/reply")
+  public ResponseEntity<ApiResponse<JournalReplyResponseDto>> createJournalReply(
+      @RequestHeader("Authorization") String bearerToken,
+      @PathVariable Long journalId
+  ) {
+    String token = bearerToken.replace("Bearer ", "");
+    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+    JournalReplyResponseDto response = journalService.createJournalReply(userId, journalId);
 
     return ResponseEntity.ok(
         ApiResponse.success(SuccessStatus.OK, response)

--- a/src/main/java/com/capstone/domain/journal/dto/response/JournalReplyResponseDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/response/JournalReplyResponseDto.java
@@ -1,0 +1,15 @@
+package com.capstone.domain.journal.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record JournalReplyResponseDto(
+    Long replyId,
+    Long journalId,
+    String content,
+    String modelName,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/capstone/domain/journal/entity/JournalReply.java
+++ b/src/main/java/com/capstone/domain/journal/entity/JournalReply.java
@@ -8,35 +8,44 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-  @Entity
-  @Table(name = "journal_reply")
-  @Getter
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
-  public class JournalReply {
+@Entity
+@Table(name = "journal_reply")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JournalReply {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Lob
-    @Column(nullable = false)
-    private String content;
+  @Lob
+  @Column(nullable = false, columnDefinition = "LONGTEXT")
+  private String content;
 
-    @Column(name = "model_name", length = 100)
-    private String modelName;
+  @Column(name = "model_name", length = 100)
+  private String modelName;
 
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "journal_id", nullable = false)
-    private Journal journal;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "journal_id", nullable = false)
+  private Journal journal;
 
-    @Builder
-    public JournalReply(String content, String modelName, LocalDateTime createdAt, Journal journal) {
-      this.content = content;
-      this.modelName = modelName;
-      this.createdAt = createdAt;
-      this.journal = journal;
-    }
+  @Builder
+  public JournalReply(String content, String modelName, LocalDateTime createdAt, Journal journal) {
+    this.content = content;
+    this.modelName = modelName;
+    this.createdAt = createdAt;
+    this.journal = journal;
   }
+
+  public static JournalReply create(String content, String modelName, Journal journal) {
+    return JournalReply.builder()
+        .content(content)
+        .modelName(modelName)
+        .createdAt(LocalDateTime.now())
+        .journal(journal)
+        .build();
+  }
+}

--- a/src/main/java/com/capstone/domain/journal/repository/JournalReplyRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalReplyRepository.java
@@ -1,0 +1,10 @@
+package com.capstone.domain.journal.repository;
+
+import com.capstone.domain.journal.entity.JournalReply;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JournalReplyRepository extends JpaRepository<JournalReply, Long> {
+  Optional<JournalReply> findTopByJournalIdOrderByCreatedAtDesc(Long journalId);
+  boolean existsByJournalId(Long journalId);
+}

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -5,7 +5,10 @@ import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
 import com.capstone.domain.journal.dto.response.JournalCursorResponseDto;
 import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
 import com.capstone.domain.journal.dto.response.JournalListItemResponseDto;
+import com.capstone.domain.journal.dto.response.JournalReplyResponseDto;
 import com.capstone.domain.journal.entity.Journal;
+import com.capstone.domain.journal.entity.JournalReply;
+import com.capstone.domain.journal.repository.JournalReplyRepository;
 import com.capstone.domain.journal.repository.JournalRepository;
 import com.capstone.domain.user.entity.User;
 import com.capstone.domain.user.repository.UserRepository;
@@ -24,8 +27,13 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class JournalService {
 
+  private static final int MAX_REPLY_SOURCE_LENGTH = 1000;
+  private static final String REPLY_MODEL_NAME = "gpt-5.4";
+
   private final JournalRepository journalRepository;
   private final UserRepository userRepository;
+  private final JournalReplyRepository journalReplyRepository;
+  private final OpenAiReplyService openAiReplyService;
 
   @Transactional
   public JournalCreateResponseDto createJournal(Long userId, JournalCreateRequestDto request) {
@@ -118,5 +126,56 @@ public class JournalService {
         .nextCursor(nextCursor)
         .hasNext(hasNext)
         .build();
+  }
+
+  @Transactional
+  public JournalReplyResponseDto createJournalReply(Long userId, Long journalId) {
+    Journal journal = journalRepository.findByIdAndIsDeletedFalse(journalId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND));
+
+    if (!journal.getUser().getId().equals(userId)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
+    }
+
+    JournalReply existingReply = journalReplyRepository
+        .findTopByJournalIdOrderByCreatedAtDesc(journalId)
+        .orElse(null);
+
+    if (existingReply != null) {
+      return JournalReplyResponseDto.builder()
+          .replyId(existingReply.getId())
+          .journalId(journal.getId())
+          .content(existingReply.getContent())
+          .modelName(existingReply.getModelName())
+          .createdAt(existingReply.getCreatedAt())
+          .build();
+    }
+
+    String truncatedContent = truncateJournalContent(journal.getContent());
+    String aiReply = openAiReplyService.generateReply(truncatedContent);
+
+    JournalReply savedReply = journalReplyRepository.save(
+        JournalReply.create(aiReply, REPLY_MODEL_NAME, journal)
+    );
+
+    return JournalReplyResponseDto.builder()
+        .replyId(savedReply.getId())
+        .journalId(journal.getId())
+        .content(savedReply.getContent())
+        .modelName(savedReply.getModelName())
+        .createdAt(savedReply.getCreatedAt())
+        .build();
+  }
+
+  private String truncateJournalContent(String content) {
+    if (content == null || content.isBlank()) {
+      throw new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND);
+    }
+
+    if (content.length() <= MAX_REPLY_SOURCE_LENGTH) {
+      return content;
+    }
+
+    return content.substring(0, MAX_REPLY_SOURCE_LENGTH);
   }
 }

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -15,6 +15,7 @@ import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.error.BusinessException;
 import com.capstone.global.error.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +29,6 @@ import java.util.List;
 public class JournalService {
 
   private static final int MAX_REPLY_SOURCE_LENGTH = 1000;
-  private static final String REPLY_MODEL_NAME = "gpt-5.4";
 
   private final JournalRepository journalRepository;
   private final UserRepository userRepository;
@@ -155,7 +155,7 @@ public class JournalService {
     String aiReply = openAiReplyService.generateReply(truncatedContent);
 
     JournalReply savedReply = journalReplyRepository.save(
-        JournalReply.create(aiReply, REPLY_MODEL_NAME, journal)
+        JournalReply.create(aiReply, openAiReplyService.getModel(), journal)
     );
 
     return JournalReplyResponseDto.builder()

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -169,7 +169,7 @@ public class JournalService {
 
   private String truncateJournalContent(String content) {
     if (content == null || content.isBlank()) {
-      throw new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND);
+      throw new BusinessException(ErrorStatus.JOURNAL_CONTENT_EMPTY);
     }
 
     if (content.length() <= MAX_REPLY_SOURCE_LENGTH) {

--- a/src/main/java/com/capstone/domain/journal/service/OpenAiReplyService.java
+++ b/src/main/java/com/capstone/domain/journal/service/OpenAiReplyService.java
@@ -70,7 +70,7 @@ public class OpenAiReplyService {
           restTemplate.exchange(url, HttpMethod.POST, request, Map.class);
 
       Map<String, Object> response = responseEntity.getBody();
-      log.info("OpenAI response body={}", response);
+      log.debug("OpenAI response body={}", response);
 
       String replyText = extractOutputText(response);
 

--- a/src/main/java/com/capstone/domain/journal/service/OpenAiReplyService.java
+++ b/src/main/java/com/capstone/domain/journal/service/OpenAiReplyService.java
@@ -2,11 +2,14 @@ package com.capstone.domain.journal.service;
 
 import com.capstone.global.error.BusinessException;
 import com.capstone.global.error.ErrorStatus;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
@@ -14,6 +17,7 @@ import java.util.Map;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class OpenAiReplyService {
 
   @Value("${openai.api-key}")
@@ -25,7 +29,8 @@ public class OpenAiReplyService {
   @Value("${openai.model}")
   private String model;
 
-  private final RestTemplate restTemplate = new RestTemplate();
+  @Qualifier("openAiRestTemplate")
+  private final RestTemplate restTemplate;
 
   public String generateReply(String journalContent) {
     try {
@@ -76,14 +81,18 @@ public class OpenAiReplyService {
 
       if (replyText == null || replyText.isBlank()) {
         log.error("OpenAI text extraction failed. full response={}", response);
-        throw new BusinessException(ErrorStatus.INTERNAL_SERVER_ERROR);
+        throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
       }
 
       return replyText.trim();
 
+    } catch (ResourceAccessException e) {
+      log.error("OpenAI timeout or connection error", e);
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
     } catch (HttpStatusCodeException e) {
-      log.error("OpenAI HTTP error status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
-      throw new BusinessException(ErrorStatus.INTERNAL_SERVER_ERROR);
+      log.error("OpenAI HTTP error status={}, body={}",
+          e.getStatusCode(), e.getResponseBodyAsString(), e);
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
     } catch (BusinessException e) {
       throw e;
     } catch (Exception e) {
@@ -92,7 +101,10 @@ public class OpenAiReplyService {
     }
   }
 
-  @SuppressWarnings("unchecked")
+  public String getModel() {
+    return model;
+  }
+
   private String extractOutputText(Map<String, Object> response) {
     if (response == null) {
       return null;
@@ -104,19 +116,13 @@ public class OpenAiReplyService {
     }
 
     for (Object outputItem : outputList) {
-      if (!(outputItem instanceof Map<?, ?> outputMap)) {
-        continue;
-      }
+      if (!(outputItem instanceof Map<?, ?> outputMap)) continue;
 
       Object contentObj = outputMap.get("content");
-      if (!(contentObj instanceof List<?> contentList) || contentList.isEmpty()) {
-        continue;
-      }
+      if (!(contentObj instanceof List<?> contentList) || contentList.isEmpty()) continue;
 
       for (Object contentItem : contentList) {
-        if (!(contentItem instanceof Map<?, ?> contentMap)) {
-          continue;
-        }
+        if (!(contentItem instanceof Map<?, ?> contentMap)) continue;
 
         Object type = contentMap.get("type");
         Object text = contentMap.get("text");

--- a/src/main/java/com/capstone/domain/journal/service/OpenAiReplyService.java
+++ b/src/main/java/com/capstone/domain/journal/service/OpenAiReplyService.java
@@ -1,0 +1,132 @@
+package com.capstone.domain.journal.service;
+
+import com.capstone.global.error.BusinessException;
+import com.capstone.global.error.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class OpenAiReplyService {
+
+  @Value("${openai.api-key}")
+  private String apiKey;
+
+  @Value("${openai.url}")
+  private String url;
+
+  @Value("${openai.model}")
+  private String model;
+
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  public String generateReply(String journalContent) {
+    try {
+      HttpHeaders headers = new HttpHeaders();
+      headers.setBearerAuth(apiKey);
+      headers.setContentType(MediaType.APPLICATION_JSON);
+
+      String prompt = """
+          너는 사용자의 글을 바탕으로, 그 사람의 내면에 있는 생각과 욕구를 자연스럽게 끌어내도록 돕는 코치다.
+
+          사용자의 저널을 읽고, 단순한 위로가 아니라 사용자가 스스로를 더 깊이 이해하고 앞으로 나아갈 수 있도록 돕는 한국어 답장을 작성해라.
+
+          목표:
+          - 사용자가 자신의 감정 뒤에 있는 진짜 이유나 원하는 것을 스스로 떠올리게 만든다
+          - 부담 없이 생각을 이어가며 자기이해와 성장을 돕는다
+
+          조건:
+          - 총 2~4문장
+          - 첫 문장: 사용자의 감정이나 상황을 조심스럽게 공감
+          - 이후 문장:
+            - 감정 뒤에 있는 이유, 욕구, 패턴을 떠올릴 수 있도록 유도하는 질문 1개 포함
+            - 또는 새로운 시각이나 작은 방향 제시
+          - 질문은 부담스럽지 않고 자연스럽게, “왜?” 대신 “혹시 ~일 수도 있을까요?” 형태로 작성
+          - 판단, 진단, 훈계 금지
+          - 감정을 단정하지 말고 가능성 형태로 표현
+          - 존댓말 사용
+          - 이모지 금지
+          - 답변만 출력
+
+          저널 내용:
+          %s
+          """.formatted(journalContent);
+
+      Map<String, Object> body = Map.of(
+          "model", model,
+          "input", prompt
+      );
+
+      HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+      ResponseEntity<Map> responseEntity =
+          restTemplate.exchange(url, HttpMethod.POST, request, Map.class);
+
+      Map<String, Object> response = responseEntity.getBody();
+      log.info("OpenAI response body={}", response);
+
+      String replyText = extractOutputText(response);
+
+      if (replyText == null || replyText.isBlank()) {
+        log.error("OpenAI text extraction failed. full response={}", response);
+        throw new BusinessException(ErrorStatus.INTERNAL_SERVER_ERROR);
+      }
+
+      return replyText.trim();
+
+    } catch (HttpStatusCodeException e) {
+      log.error("OpenAI HTTP error status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+      throw new BusinessException(ErrorStatus.INTERNAL_SERVER_ERROR);
+    } catch (BusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("OpenAI unexpected error", e);
+      throw new BusinessException(ErrorStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private String extractOutputText(Map<String, Object> response) {
+    if (response == null) {
+      return null;
+    }
+
+    Object outputObj = response.get("output");
+    if (!(outputObj instanceof List<?> outputList) || outputList.isEmpty()) {
+      return null;
+    }
+
+    for (Object outputItem : outputList) {
+      if (!(outputItem instanceof Map<?, ?> outputMap)) {
+        continue;
+      }
+
+      Object contentObj = outputMap.get("content");
+      if (!(contentObj instanceof List<?> contentList) || contentList.isEmpty()) {
+        continue;
+      }
+
+      for (Object contentItem : contentList) {
+        if (!(contentItem instanceof Map<?, ?> contentMap)) {
+          continue;
+        }
+
+        Object type = contentMap.get("type");
+        Object text = contentMap.get("text");
+
+        if ("output_text".equals(type) && text instanceof String textValue && !textValue.isBlank()) {
+          return textValue;
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/capstone/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/capstone/global/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.capstone.global.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  @Qualifier("openAiRestTemplate")
+  public RestTemplate openAiRestTemplate() {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(5000);   // 연결 타임아웃 (5sec)
+    factory.setReadTimeout(30000);     // 응답 대기 (30sec)
+
+    return new RestTemplate(factory);
+  }
+}

--- a/src/main/java/com/capstone/global/error/ErrorStatus.java
+++ b/src/main/java/com/capstone/global/error/ErrorStatus.java
@@ -40,6 +40,7 @@ public enum ErrorStatus {
   NOT_FOUND_HANDLER(40401, HttpStatus.NOT_FOUND, "존재하지 않는 API 경로입니다."),
   REFRESH_TOKEN_NOT_FOUND(40402, HttpStatus.NOT_FOUND, "저장된 리프레시 토큰이 없습니다."),
   JOURNAL_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "해당 저널을 찾을 수 없습니다."),
+  JOURNAL_CONTENT_EMPTY(40004, HttpStatus.BAD_REQUEST, "저널 내용이 비어 있습니다."),
   /**
    * 405 Method Not Allowed
    */

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -67,3 +67,9 @@ logging:
   level:
     root: INFO
     org.sopt: DEBUG
+
+# 10. Open Ai
+openai:
+  api-key: ${OPENAI_API_KEY}
+  url: ${OPENAI_URL}
+  model: ${OPENAI_MODEL}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #28 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- OpenAI API를 활용한 저널 AI 답변 생성 기능 추가
- OpenAiReplyService를 통해 저널 내용을 기반으로 감정 코칭 응답 생성
- 저널당 AI 답변 1회 생성 로직 구현 (중복 생성 방지)
- JournalReply 엔티티 및 Repository 추가
- AI 응답 결과를 DB에 저장하도록 구조 설계
- /api/v1/journals/{journalId}/reply API 추가
- JWT 기반 사용자 검증 후 해당 저널에 대한 답변 생성 처리
- AI 응답 길이 증가에 대응하기 위해 journal_reply.content 컬럼을 LONGTEXT로 확장
- 응답 길이 제한 로직 추가하여 저장 안정성 확보

## 📸 테스트 증명 (필수)
- 응답을 받을 모닝저널
<img width="2102" height="699" alt="image" src="https://github.com/user-attachments/assets/38335654-6be3-4686-98e6-4c4f574ae921" />

</br>
- AI 답장
<img width="2124" height="757" alt="image" src="https://github.com/user-attachments/assets/0857fae3-dbc1-4d4d-b5f4-6c9c68216879" />



## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 저널 항목에 대한 AI 기반 자동 응답 생성 기능 추가
  * 사용자가 자신의 저널에 대한 지능형 회신을 요청할 수 있으며, 동일한 저널에 대해 이미 생성된 회신은 재사용됨
  * OpenAI 통합을 통한 한국어 회신 생성 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->