### PR TITLE
[FEAT] 키워드 get api 구현, reply api에 키워드 분석 요청 추가

### DIFF
--- a/src/main/java/com/capstone/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/capstone/domain/journal/controller/JournalController.java
@@ -1,15 +1,17 @@
 package com.capstone.domain.journal.controller;
 
 import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
+import com.capstone.domain.journal.dto.response.JournalAnalyzeResponseDto;
 import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
 import com.capstone.domain.journal.dto.response.JournalCursorResponseDto;
 import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
-import com.capstone.domain.journal.dto.response.JournalReplyResponseDto;
+import com.capstone.domain.journal.dto.response.JournalKeywordItemDto;
 import com.capstone.domain.journal.service.JournalService;
 import com.capstone.global.common.ApiResponse;
 import com.capstone.global.common.SuccessStatus;
 import com.capstone.global.security.jwt.JwtTokenProvider;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -97,6 +99,22 @@ public class JournalController {
 
     JournalAnalyzeResponseDto response =
         journalService.createJournalReply(userId, journalId);
+
+    return ResponseEntity.ok(
+        ApiResponse.success(SuccessStatus.OK, response)
+    );
+  }
+
+  @GetMapping("/{journalId}/keywords")
+  public ResponseEntity<ApiResponse<List<JournalKeywordItemDto>>> getKeywords(
+      @RequestHeader("Authorization") String bearerToken,
+      @PathVariable Long journalId
+  ) {
+    String token = bearerToken.replace("Bearer ", "");
+    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+    List<JournalKeywordItemDto> response =
+        journalService.getKeywords(userId, journalId);
 
     return ResponseEntity.ok(
         ApiResponse.success(SuccessStatus.OK, response)

--- a/src/main/java/com/capstone/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/capstone/domain/journal/controller/JournalController.java
@@ -88,14 +88,15 @@ public class JournalController {
   }
 
   @PostMapping("/{journalId}/reply")
-  public ResponseEntity<ApiResponse<JournalReplyResponseDto>> createJournalReply(
+  public ResponseEntity<ApiResponse<JournalAnalyzeResponseDto>> createJournalReply(
       @RequestHeader("Authorization") String bearerToken,
       @PathVariable Long journalId
   ) {
     String token = bearerToken.replace("Bearer ", "");
     Long userId = jwtTokenProvider.getUserIdFromToken(token);
 
-    JournalReplyResponseDto response = journalService.createJournalReply(userId, journalId);
+    JournalAnalyzeResponseDto response =
+        journalService.createJournalReply(userId, journalId);
 
     return ResponseEntity.ok(
         ApiResponse.success(SuccessStatus.OK, response)

--- a/src/main/java/com/capstone/domain/journal/dto/response/JournalAiResultDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/response/JournalAiResultDto.java
@@ -1,0 +1,16 @@
+package com.capstone.domain.journal.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record JournalAiResultDto(
+    String reply,
+    String summary,
+    List<KeywordItem> keywords
+) {
+  public record KeywordItem(
+      String name,
+      BigDecimal score
+  ) {
+  }
+}

--- a/src/main/java/com/capstone/domain/journal/dto/response/JournalAnalyzeResponseDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/response/JournalAnalyzeResponseDto.java
@@ -1,0 +1,13 @@
+package com.capstone.domain.journal.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record JournalAnalyzeResponseDto(
+    Long journalId,
+    String summary,
+    String reply,
+    List<JournalKeywordItemDto> keywords
+) {
+}

--- a/src/main/java/com/capstone/domain/journal/dto/response/JournalKeywordItemDto.java
+++ b/src/main/java/com/capstone/domain/journal/dto/response/JournalKeywordItemDto.java
@@ -1,0 +1,11 @@
+package com.capstone.domain.journal.dto.response;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+
+@Builder
+public record JournalKeywordItemDto(
+    String keyword,
+    BigDecimal score
+) {
+}

--- a/src/main/java/com/capstone/domain/journal/entity/JournalAnalysis.java
+++ b/src/main/java/com/capstone/domain/journal/entity/JournalAnalysis.java
@@ -39,9 +39,6 @@ public class JournalAnalysis {
   @OneToMany(mappedBy = "journalAnalysis")
   private List<JournalKeyword> journalKeywords = new ArrayList<>();
 
-  @OneToMany(mappedBy = "journalAnalysis")
-  private List<JournalEmotion> journalEmotions = new ArrayList<>();
-
   @Builder
   public JournalAnalysis(String summary, String modelName, String version,
       LocalDateTime analyzedAt, Journal journal) {
@@ -50,5 +47,14 @@ public class JournalAnalysis {
     this.version = version;
     this.analyzedAt = analyzedAt;
     this.journal = journal;
+  }
+  public static JournalAnalysis create(String summary, String modelName, String version, Journal journal) {
+    return JournalAnalysis.builder()
+        .summary(summary)
+        .modelName(modelName)
+        .version(version)
+        .analyzedAt(LocalDateTime.now())
+        .journal(journal)
+        .build();
   }
 }

--- a/src/main/java/com/capstone/domain/journal/repository/JournalAnalysisRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalAnalysisRepository.java
@@ -1,0 +1,9 @@
+package com.capstone.domain.journal.repository;
+
+import com.capstone.domain.journal.entity.JournalAnalysis;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JournalAnalysisRepository extends JpaRepository<JournalAnalysis, Long> {
+  Optional<JournalAnalysis> findTopByJournalIdOrderByAnalyzedAtDesc(Long journalId);
+}

--- a/src/main/java/com/capstone/domain/journal/repository/JournalKeywordRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalKeywordRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.domain.journal.repository;
+
+import com.capstone.domain.journal.entity.JournalKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JournalKeywordRepository extends JpaRepository<JournalKeyword, Long> {
+}

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -15,7 +15,6 @@ import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.error.BusinessException;
 import com.capstone.global.error.ErrorStatus;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +32,7 @@ public class JournalService {
   private final JournalRepository journalRepository;
   private final UserRepository userRepository;
   private final JournalReplyRepository journalReplyRepository;
-  private final OpenAiReplyService openAiReplyService;
+  private final OpenAiJournalAiService openAiReplyService;
 
   @Transactional
   public JournalCreateResponseDto createJournal(Long userId, JournalCreateRequestDto request) {

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -1,15 +1,11 @@
 package com.capstone.domain.journal.service;
 
 import com.capstone.domain.journal.dto.request.JournalCreateRequestDto;
-import com.capstone.domain.journal.dto.response.JournalCreateResponseDto;
-import com.capstone.domain.journal.dto.response.JournalCursorResponseDto;
-import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
-import com.capstone.domain.journal.dto.response.JournalListItemResponseDto;
-import com.capstone.domain.journal.dto.response.JournalReplyResponseDto;
-import com.capstone.domain.journal.entity.Journal;
-import com.capstone.domain.journal.entity.JournalReply;
-import com.capstone.domain.journal.repository.JournalReplyRepository;
-import com.capstone.domain.journal.repository.JournalRepository;
+import com.capstone.domain.journal.dto.response.*;
+import com.capstone.domain.journal.entity.*;
+import com.capstone.domain.journal.repository.*;
+import com.capstone.domain.keyword.entity.Keyword;
+import com.capstone.domain.keyword.repository.KeywordRepository;
 import com.capstone.domain.user.entity.User;
 import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.error.BusinessException;
@@ -20,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -32,7 +29,10 @@ public class JournalService {
   private final JournalRepository journalRepository;
   private final UserRepository userRepository;
   private final JournalReplyRepository journalReplyRepository;
-  private final OpenAiJournalAiService openAiReplyService;
+  private final JournalAnalysisRepository journalAnalysisRepository;
+  private final JournalKeywordRepository journalKeywordRepository;
+  private final KeywordRepository keywordRepository;
+  private final OpenAiJournalAiService openAiJournalAiService;
 
   @Transactional
   public JournalCreateResponseDto createJournal(Long userId, JournalCreateRequestDto request) {
@@ -74,7 +74,6 @@ public class JournalService {
     journal.delete();
   }
 
-  @Transactional(readOnly = true)
   public JournalGetResponseDto getJournalByDate(Long userId, LocalDate date) {
     Journal journal = journalRepository
         .findByUserIdAndJournalDateAndIsDeletedFalse(userId, date)
@@ -89,7 +88,6 @@ public class JournalService {
         .build();
   }
 
-  @Transactional(readOnly = true)
   public JournalCursorResponseDto getJournalList(Long userId, Long cursor, int size) {
     int pageSize = Math.max(1, Math.min(size, 50));
 
@@ -115,10 +113,7 @@ public class JournalService {
             .build())
         .toList();
 
-    Long nextCursor = null;
-    if (hasNext && !journals.isEmpty()) {
-      nextCursor = journals.get(journals.size() - 1).getId();
-    }
+    Long nextCursor = hasNext ? journals.get(journals.size() - 1).getId() : null;
 
     return JournalCursorResponseDto.builder()
         .journals(journalList)
@@ -128,7 +123,8 @@ public class JournalService {
   }
 
   @Transactional
-  public JournalReplyResponseDto createJournalReply(Long userId, Long journalId) {
+  public JournalAnalyzeResponseDto createJournalReply(Long userId, Long journalId) {
+
     Journal journal = journalRepository.findByIdAndIsDeletedFalse(journalId)
         .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND));
 
@@ -136,33 +132,132 @@ public class JournalService {
       throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
     }
 
-    JournalReply existingReply = journalReplyRepository
-        .findTopByJournalIdOrderByCreatedAtDesc(journalId)
+    JournalAnalysis existingAnalysis = journalAnalysisRepository
+        .findTopByJournalIdOrderByAnalyzedAtDesc(journalId)
         .orElse(null);
 
-    if (existingReply != null) {
-      return JournalReplyResponseDto.builder()
-          .replyId(existingReply.getId())
-          .journalId(journal.getId())
-          .content(existingReply.getContent())
-          .modelName(existingReply.getModelName())
-          .createdAt(existingReply.getCreatedAt())
-          .build();
+    if (existingAnalysis != null) {
+      return mapToAnalyzeResponse(journalId, existingAnalysis);
     }
 
     String truncatedContent = truncateJournalContent(journal.getContent());
-    String aiReply = openAiReplyService.generateReply(truncatedContent);
+    JournalAiResultDto aiResult =
+        openAiJournalAiService.generateAnalysisResult(truncatedContent);
 
-    JournalReply savedReply = journalReplyRepository.save(
-        JournalReply.create(aiReply, openAiReplyService.getModel(), journal)
+    JournalAnalysis savedAnalysis = journalAnalysisRepository.save(
+        JournalAnalysis.create(
+            aiResult.summary(),
+            openAiJournalAiService.getModel(),
+            "v1",
+            journal
+        )
     );
 
-    return JournalReplyResponseDto.builder()
-        .replyId(savedReply.getId())
-        .journalId(journal.getId())
-        .content(savedReply.getContent())
-        .modelName(savedReply.getModelName())
-        .createdAt(savedReply.getCreatedAt())
+    boolean exists = journalReplyRepository
+        .findTopByJournalIdOrderByCreatedAtDesc(journalId)
+        .isPresent();
+
+    if (!exists) {
+      journalReplyRepository.save(
+          JournalReply.create(
+              aiResult.reply(),
+              openAiJournalAiService.getModel(),
+              journal
+          )
+      );
+    }
+
+    List<JournalKeyword> savedKeywords = saveKeywords(savedAnalysis, aiResult.keywords());
+
+    return mapToAnalyzeResponse(journalId, savedAnalysis, savedKeywords);
+  }
+
+  private List<JournalKeyword> saveKeywords(JournalAnalysis analysis,
+      List<JournalAiResultDto.KeywordItem> keywords) {
+    List<JournalKeyword> saved = new ArrayList<>();
+
+    for (JournalAiResultDto.KeywordItem item : keywords) {
+      Keyword keyword = keywordRepository.findByName(item.name())
+          .orElseGet(() -> keywordRepository.save(
+              Keyword.builder()
+                  .name(item.name())
+                  .build()
+          ));
+
+      JournalKeyword jk = journalKeywordRepository.save(
+          JournalKeyword.builder()
+              .score(item.score())
+              .journalAnalysis(analysis)
+              .keyword(keyword)
+              .build()
+      );
+      saved.add(jk);
+    }
+
+    return saved;
+  }
+
+  public List<JournalKeywordItemDto> getKeywords(Long userId, Long journalId) {
+
+    Journal journal = journalRepository.findByIdAndIsDeletedFalse(journalId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND));
+
+    if (!journal.getUser().getId().equals(userId)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
+    }
+
+    JournalAnalysis analysis = journalAnalysisRepository
+        .findTopByJournalIdOrderByAnalyzedAtDesc(journalId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND));
+
+    return analysis.getJournalKeywords().stream()
+        .map(journalKeyword -> JournalKeywordItemDto.builder()
+            .keyword(journalKeyword.getKeyword().getName())
+            .score(journalKeyword.getScore())
+            .build())
+        .toList();
+  }
+
+  private JournalAnalyzeResponseDto mapToAnalyzeResponse(Long journalId, JournalAnalysis analysis) {
+
+    List<JournalKeywordItemDto> keywordItems = analysis.getJournalKeywords().stream()
+        .map(journalKeyword -> JournalKeywordItemDto.builder()
+            .keyword(journalKeyword.getKeyword().getName())
+            .score(journalKeyword.getScore())
+            .build())
+        .toList();
+
+    String reply = journalReplyRepository.findTopByJournalIdOrderByCreatedAtDesc(journalId)
+        .map(JournalReply::getContent)
+        .orElse(null);
+
+    return JournalAnalyzeResponseDto.builder()
+        .journalId(journalId)
+        .summary(analysis.getSummary())
+        .reply(reply)
+        .keywords(keywordItems)
+        .build();
+  }
+
+  private JournalAnalyzeResponseDto mapToAnalyzeResponse(Long journalId, JournalAnalysis analysis,
+      List<JournalKeyword> keywords) {
+
+    List<JournalKeywordItemDto> keywordItems = keywords.stream()
+        .map(jk -> JournalKeywordItemDto.builder()
+            .keyword(jk.getKeyword().getName())
+            .score(jk.getScore())
+            .build())
+        .toList();
+
+    String reply = journalReplyRepository.findTopByJournalIdOrderByCreatedAtDesc(journalId)
+        .map(JournalReply::getContent)
+        .orElse(null);
+
+    return JournalAnalyzeResponseDto.builder()
+        .journalId(journalId)
+        .summary(analysis.getSummary())
+        .reply(reply)
+        .keywords(keywordItems)
         .build();
   }
 
@@ -171,10 +266,8 @@ public class JournalService {
       throw new BusinessException(ErrorStatus.JOURNAL_CONTENT_EMPTY);
     }
 
-    if (content.length() <= MAX_REPLY_SOURCE_LENGTH) {
-      return content;
-    }
-
-    return content.substring(0, MAX_REPLY_SOURCE_LENGTH);
+    return content.length() <= MAX_REPLY_SOURCE_LENGTH
+        ? content
+        : content.substring(0, MAX_REPLY_SOURCE_LENGTH);
   }
 }

--- a/src/main/java/com/capstone/domain/journal/service/OpenAiJournalAiService.java
+++ b/src/main/java/com/capstone/domain/journal/service/OpenAiJournalAiService.java
@@ -18,7 +18,7 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class OpenAiReplyService {
+public class OpenAiJournalAiService {
 
   @Value("${openai.api-key}")
   private String apiKey;

--- a/src/main/java/com/capstone/domain/journal/service/OpenAiJournalAiService.java
+++ b/src/main/java/com/capstone/domain/journal/service/OpenAiJournalAiService.java
@@ -1,12 +1,19 @@
 package com.capstone.domain.journal.service;
 
+import com.capstone.domain.journal.dto.response.JournalAiResultDto;
 import com.capstone.global.error.BusinessException;
 import com.capstone.global.error.ErrorStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
@@ -20,6 +27,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OpenAiJournalAiService {
 
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
   @Value("${openai.api-key}")
   private String apiKey;
 
@@ -32,34 +41,44 @@ public class OpenAiJournalAiService {
   @Qualifier("openAiRestTemplate")
   private final RestTemplate restTemplate;
 
-  public String generateReply(String journalContent) {
+  public JournalAiResultDto generateAnalysisResult(String journalContent) {
     try {
       HttpHeaders headers = new HttpHeaders();
       headers.setBearerAuth(apiKey);
       headers.setContentType(MediaType.APPLICATION_JSON);
 
       String prompt = """
-          너는 사용자의 글을 바탕으로, 그 사람의 내면에 있는 생각과 욕구를 자연스럽게 끌어내도록 돕는 코치다.
-
-          사용자의 저널을 읽고, 단순한 위로가 아니라 사용자가 스스로를 더 깊이 이해하고 앞으로 나아갈 수 있도록 돕는 한국어 답장을 작성해라.
-
+          너는 사용자의 저널을 분석하는 AI 코치다.
+          
+          사용자의 저널을 읽고, 아래 JSON 형식으로만 답변하라.
+          설명 문장, 코드블록 마크다운, 부가 설명 없이 JSON만 출력하라.
+          
           목표:
-          - 사용자가 자신의 감정 뒤에 있는 진짜 이유나 원하는 것을 스스로 떠올리게 만든다
-          - 부담 없이 생각을 이어가며 자기이해와 성장을 돕는다
-
+          - 사용자의 내면 욕구, 방향성, 감정 흐름을 바탕으로 짧은 답장을 만든다
+          - 저널 핵심 내용을 요약한다
+          - 핵심 키워드 3개를 추출한다
+          
           조건:
-          - 총 2~4문장
-          - 첫 문장: 사용자의 감정이나 상황을 조심스럽게 공감
-          - 이후 문장:
-            - 감정 뒤에 있는 이유, 욕구, 패턴을 떠올릴 수 있도록 유도하는 질문 1개 포함
-            - 또는 새로운 시각이나 작은 방향 제시
-          - 질문은 부담스럽지 않고 자연스럽게, “왜?” 대신 “혹시 ~일 수도 있을까요?” 형태로 작성
+          - reply는 2~4문장
+          - summary는 1~2문장
+          - keywords는 정확히 3개
+          - keywords.score는 0 이상 1 이하의 소수
+          - reply는 공감 + 자기이해/성장 방향 제시가 포함되어야 한다
           - 판단, 진단, 훈계 금지
-          - 감정을 단정하지 말고 가능성 형태로 표현
           - 존댓말 사용
           - 이모지 금지
-          - 답변만 출력
-
+          
+          반드시 아래 형식의 JSON만 출력:
+          {
+            "reply": "사용자에게 보여줄 답장",
+            "summary": "저널 핵심 요약",
+            "keywords": [
+              {"name": "키워드1", "score": 0.91},
+              {"name": "키워드2", "score": 0.84},
+              {"name": "키워드3", "score": 0.79}
+            ]
+          }
+          
           저널 내용:
           %s
           """.formatted(journalContent);
@@ -77,14 +96,19 @@ public class OpenAiJournalAiService {
       Map<String, Object> response = responseEntity.getBody();
       log.debug("OpenAI response body={}", response);
 
-      String replyText = extractOutputText(response);
+      String rawText = extractOutputText(response);
 
-      if (replyText == null || replyText.isBlank()) {
+      if (rawText == null || rawText.isBlank()) {
         log.error("OpenAI text extraction failed. full response={}", response);
         throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
       }
 
-      return replyText.trim();
+      String cleanedJson = cleanJsonText(rawText);
+      JournalAiResultDto result =
+          objectMapper.readValue(cleanedJson, JournalAiResultDto.class);
+
+      validateResult(result);
+      return result;
 
     } catch (ResourceAccessException e) {
       log.error("OpenAI timeout or connection error", e);
@@ -92,6 +116,9 @@ public class OpenAiJournalAiService {
     } catch (HttpStatusCodeException e) {
       log.error("OpenAI HTTP error status={}, body={}",
           e.getStatusCode(), e.getResponseBodyAsString(), e);
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
+    } catch (JsonProcessingException e) {
+      log.error("OpenAI JSON parsing failed", e);
       throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
     } catch (BusinessException e) {
       throw e;
@@ -105,6 +132,48 @@ public class OpenAiJournalAiService {
     return model;
   }
 
+  private void validateResult(JournalAiResultDto result) {
+    if (result == null) {
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
+    }
+
+    if (result.reply() == null || result.reply().isBlank()) {
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
+    }
+
+    if (result.summary() == null || result.summary().isBlank()) {
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
+    }
+
+    if (result.keywords() == null || result.keywords().size() != 3) {
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
+    }
+
+    boolean invalidKeyword = result.keywords().stream().anyMatch(keyword ->
+        keyword.name() == null || keyword.name().isBlank() || keyword.score() == null
+    );
+
+    if (invalidKeyword) {
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
+    }
+  }
+
+  private String cleanJsonText(String rawText) {
+    String trimmed = rawText.trim();
+
+    if (trimmed.startsWith("```json")) {
+      trimmed = trimmed.substring(7).trim();
+    } else if (trimmed.startsWith("```")) {
+      trimmed = trimmed.substring(3).trim();
+    }
+
+    if (trimmed.endsWith("```")) {
+      trimmed = trimmed.substring(0, trimmed.length() - 3).trim();
+    }
+
+    return trimmed;
+  }
+
   private String extractOutputText(Map<String, Object> response) {
     if (response == null) {
       return null;
@@ -116,13 +185,19 @@ public class OpenAiJournalAiService {
     }
 
     for (Object outputItem : outputList) {
-      if (!(outputItem instanceof Map<?, ?> outputMap)) continue;
+      if (!(outputItem instanceof Map<?, ?> outputMap)) {
+        continue;
+      }
 
       Object contentObj = outputMap.get("content");
-      if (!(contentObj instanceof List<?> contentList) || contentList.isEmpty()) continue;
+      if (!(contentObj instanceof List<?> contentList) || contentList.isEmpty()) {
+        continue;
+      }
 
       for (Object contentItem : contentList) {
-        if (!(contentItem instanceof Map<?, ?> contentMap)) continue;
+        if (!(contentItem instanceof Map<?, ?> contentMap)) {
+          continue;
+        }
 
         Object type = contentMap.get("type");
         Object text = contentMap.get("text");

--- a/src/main/java/com/capstone/domain/keyword/entity/Keyword.java
+++ b/src/main/java/com/capstone/domain/keyword/entity/Keyword.java
@@ -21,13 +21,13 @@ public class Keyword {
   private Long id;
 
   @Column(name = "keyword_name", nullable = false, length = 255)
-  private String keywordName;
+  private String name;
 
   @OneToMany(mappedBy = "keyword")
   private List<JournalKeyword> journalKeywords = new ArrayList<>();
 
   @Builder
-  public Keyword(String keywordName) {
-    this.keywordName = keywordName;
+  public Keyword(String name) {
+    this.name = name;
   }
 }

--- a/src/main/java/com/capstone/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/capstone/domain/keyword/repository/KeywordRepository.java
@@ -1,0 +1,9 @@
+package com.capstone.domain.keyword.repository;
+
+import com.capstone.domain.keyword.entity.Keyword;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+  Optional<Keyword> findByName(String name);
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #27 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- reply API에서 AI 답장 + 요약 + 키워드 생성/저장 통합 처리
- analyze API 제거 및 단일 흐름으로 구조 단순화
- 키워드 조회 API 분리 (GET /journals/{journalId}/keywords)
- 키워드가 항상 존재하도록 생성 시점에 DB 저장 구조로 변경
- saveKeywords() → 저장된 키워드 리스트 반환하도록 수정
- mapToAnalyzeResponse() → DB 조회 대신 전달받은 키워드 사용
- 키워드 응답 빈 배열 문제 해결 (영속성 타이밍 이슈 해결)
- getKeywords()에 사용자 권한 체크 추가 (보안 강화)
- reply 중복 생성 방지 로직 추가 (동시 요청 대응)

## 📸 테스트 증명 (필수)
<img width="1165" height="991" alt="image" src="https://github.com/user-attachments/assets/c067586d-5e3a-4cc7-a395-68dc1ca88fe2" />
<img width="1172" height="799" alt="image" src="https://github.com/user-attachments/assets/9cb72a72-0e57-4f6e-8ecd-918ed4e9ef5e" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [ ] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [ ] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [ ] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [ ] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 저널 분석 기능이 개선되어 이제 요약, 답변, 추출된 키워드를 함께 제공합니다.
  * 새로운 키워드 조회 API 엔드포인트가 추가되었습니다. 특정 저널의 분석된 키워드를 조회할 수 있습니다.
  * AI 기반 자동 분석으로 저널의 주요 키워드와 점수가 자동으로 추출됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->