### PR TITLE
[FEAT] 마이페이지 API 구현

### DIFF
--- a/src/main/java/com/capstone/domain/user/controller/UserController.java
+++ b/src/main/java/com/capstone/domain/user/controller/UserController.java
@@ -1,7 +1,13 @@
 package com.capstone.domain.user.controller;
 
+import com.capstone.domain.user.dto.response.MyPageResponseDto;
 import com.capstone.domain.user.service.UserService;
+import com.capstone.global.common.ApiResponse;
+import com.capstone.global.common.SuccessStatus;
+import com.capstone.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -10,4 +16,12 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
   private final UserService userService;
+
+  @GetMapping("/me")
+  public ResponseEntity<ApiResponse<MyPageResponseDto>> getMyPage(
+      @AuthenticationPrincipal UserPrincipal userPrincipal
+  ) {
+    MyPageResponseDto response = userService.getMyPage(userPrincipal.getUserId());
+    return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, response));
+  }
 }

--- a/src/main/java/com/capstone/domain/user/dto/response/MyPageResponseDto.java
+++ b/src/main/java/com/capstone/domain/user/dto/response/MyPageResponseDto.java
@@ -1,0 +1,8 @@
+package com.capstone.domain.user.dto.response;
+
+public record MyPageResponseDto(
+    String email,
+    String nickname,
+    Long cloverBalance,
+    String cloverComment
+) {}

--- a/src/main/java/com/capstone/domain/user/service/UserService.java
+++ b/src/main/java/com/capstone/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.capstone.domain.user.service;
 
+import com.capstone.domain.user.dto.response.MyPageResponseDto;
 import com.capstone.domain.user.entity.User;
 import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.error.BusinessException;
@@ -18,5 +19,28 @@ public class UserService {
   public User getUserById(Long userId) {
     return userRepository.findById(userId)
         .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
+  }
+
+  public MyPageResponseDto getMyPage(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
+
+    return new MyPageResponseDto(
+        user.getEmail(),
+        user.getNickname(),
+        user.getCloverBalance(),
+        resolveCloverComment(user.getCloverBalance())
+    );
+  }
+
+  private String resolveCloverComment(Long clover) {
+    if (clover == null || clover == 0) return "아직 첫 저널을 기다리고 있어요!";
+    if (clover <= 3)   return "새싹 모닝저널러!";
+    if (clover <= 7)   return "성장 중인 모닝저널러!";
+    if (clover <= 14)  return "꾸준한 모닝저널러!";
+    if (clover <= 30)  return "열혈 모닝저널러!";
+    if (clover <= 60)  return "모닝저널 고수!";
+    if (clover <= 100) return "전설의 모닝저널러!";
+    return "모닝저널 레전드!";
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #43 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
  - `GET /api/v1/users/me` 마이페이지 조회 API 구현
  - 로그인한 사용자의 이메일, 닉네임, 클로버 갯수 반환
  - 클로버 갯수(연속 작성일수) 구간별 코멘트 제공
    - 0일: 아직 첫 저널을 기다리고 있어요!
    - 1~3일: 새싹 모닝저널러!
    - 4~7일: 성장 중인 모닝저널러!
    - 8~14일: 꾸준한 모닝저널러!
    - 15~30일: 열혈 모닝저널러!
    - 31~60일: 모닝저널 고수!
    - 61~100일: 전설의 모닝저널러!
    - 100일 초과: 모닝저널 레전드!
    -
## 📸 테스트 증명 (필수)
<img width="1047" height="301" alt="image" src="https://github.com/user-attachments/assets/6d1e37e6-2502-4238-9798-201a1b29d862" />


## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?