### PR TITLE
[FEAT]ai 답장 get api 구현

### DIFF
--- a/src/main/java/com/capstone/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/capstone/domain/journal/controller/JournalController.java
@@ -4,6 +4,7 @@ import com.capstone.domain.journal.dto.response.JournalAnalyzeResponseDto;
 import com.capstone.domain.journal.dto.response.JournalCursorResponseDto;
 import com.capstone.domain.journal.dto.response.JournalGetResponseDto;
 import com.capstone.domain.journal.dto.response.JournalKeywordItemDto;
+import com.capstone.domain.journal.dto.response.JournalReplyResponseDto;
 import com.capstone.domain.journal.service.JournalService;
 import com.capstone.global.common.ApiResponse;
 import com.capstone.global.common.SuccessStatus;
@@ -63,6 +64,20 @@ public class JournalController {
     LocalDate date = LocalDate.of(year, month, day);
 
     JournalGetResponseDto response = journalService.getJournalByDate(userPrincipal.getUserId(), date);
+
+    return ResponseEntity.ok(
+        ApiResponse.success(SuccessStatus.OK, response)
+    );
+  }
+
+  @Operation(summary = "AI 저널 답장 조회")
+  @GetMapping("/{journalId}/reply")
+  public ResponseEntity<ApiResponse<JournalReplyResponseDto>> getJournalReply(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @PathVariable Long journalId
+  ) {
+    JournalReplyResponseDto response =
+        journalService.getJournalReply(userPrincipal.getUserId(), journalId);
 
     return ResponseEntity.ok(
         ApiResponse.success(SuccessStatus.OK, response)

--- a/src/main/java/com/capstone/domain/journal/service/JournalService.java
+++ b/src/main/java/com/capstone/domain/journal/service/JournalService.java
@@ -214,6 +214,26 @@ public class JournalService {
     return mapToAnalyzeResponse(journalId, savedAnalysis, savedKeywords);
   }
 
+  public JournalReplyResponseDto getJournalReply(Long userId, Long journalId) {
+    Journal journal = journalRepository.findByIdAndIsDeletedFalse(journalId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_NOT_FOUND));
+
+    if (!journal.getUser().getId().equals(userId)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
+    }
+
+    JournalReply reply = journalReplyRepository.findTopByJournalIdOrderByCreatedAtDesc(journalId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.JOURNAL_REPLY_NOT_FOUND));
+
+    return JournalReplyResponseDto.builder()
+        .replyId(reply.getId())
+        .journalId(journalId)
+        .content(reply.getContent())
+        .modelName(reply.getModelName())
+        .createdAt(reply.getCreatedAt())
+        .build();
+  }
+
   public List<JournalKeywordItemDto> getKeywords(Long userId, Long journalId) {
 
     Journal journal = journalRepository.findByIdAndIsDeletedFalse(journalId)

--- a/src/main/java/com/capstone/global/error/ErrorStatus.java
+++ b/src/main/java/com/capstone/global/error/ErrorStatus.java
@@ -40,6 +40,7 @@ public enum ErrorStatus {
   NOT_FOUND_HANDLER(40401, HttpStatus.NOT_FOUND, "존재하지 않는 API 경로입니다."),
   REFRESH_TOKEN_NOT_FOUND(40402, HttpStatus.NOT_FOUND, "저장된 리프레시 토큰이 없습니다."),
   JOURNAL_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "해당 저널을 찾을 수 없습니다."),
+  JOURNAL_REPLY_NOT_FOUND(40405, HttpStatus.NOT_FOUND, "해당 저널의 AI 답장이 아직 생성되지 않았습니다."),
   JOURNAL_CONTENT_EMPTY(40004, HttpStatus.BAD_REQUEST, "저널 내용이 비어 있습니다."),
   NICKNAME_CONTAINS_BAD_WORD(40005, HttpStatus.BAD_REQUEST, "닉네임에 비속어를 사용할 수 없습니다."),
   QUESTION_ALREADY_ANSWERED(40006, HttpStatus.BAD_REQUEST, "이미 답변한 질문입니다."),


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #49 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- `GET /api/v1/journals/{journalId}/reply` 엔드포인트 추가
- 히스토리에서 저널 재조회 시 AI 답장을 조회 전용 API로 분리
- 기존 `POST /reply`는 최초 생성 전용으로 유지, 이미 생성된 답장은 GET으로 조회
- 답장 미존재 시 `404 JOURNAL_REPLY_NOT_FOUND` 반환

## 📸 테스트 증명 (필수)

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [ ] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [ ] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [ ] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [ ] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * AI 저널 답장 조회 기능 추가 - 생성된 AI 답장을 언제든지 조회할 수 있습니다.

* **Bug Fixes**
  * 저널 답장 미생성 시 명확한 오류 메시지 처리 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/4-1-Capstone-Design/CAPSTONE-SERVER/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->