### PR TITLE
[REFACT] top3감정 추출 정규화 적용

### DIFF
--- a/ml-server/main.py
+++ b/ml-server/main.py
@@ -31,15 +31,16 @@ def predict(req: Request):
 
     probs = torch.nn.functional.softmax(outputs.logits, dim=-1)
 
-    # Top-3 추출
+    # Top-3 추출 후 합이 1이 되도록 정규화
     topk = torch.topk(probs, 3)
+    topk_sum = topk.values[0].sum().item()
 
     results = []
     for i in range(3):
         idx = topk.indices[0][i].item()
         results.append({
             "label": label_map[idx],
-            "score": float(topk.values[0][i].item())
+            "score": float(topk.values[0][i].item()) / topk_sum
         })
 
     return {

--- a/src/main/java/com/capstone/domain/stats/service/StatsService.java
+++ b/src/main/java/com/capstone/domain/stats/service/StatsService.java
@@ -3,7 +3,6 @@ package com.capstone.domain.stats.service;
 import com.capstone.domain.journal.repository.JournalKeywordRepository;
 import com.capstone.domain.journal.repository.JournalRepository;
 import com.capstone.domain.question.repository.DailyQuestionRepository;
-import com.capstone.domain.question.repository.QuestionAnswerKeywordRepository;
 import com.capstone.domain.stats.dto.MonthlyStatsResponseDto;
 import com.capstone.domain.stats.dto.MonthlyStatsResponseDto.EmotionStatDto;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +20,6 @@ public class StatsService {
     private final JournalRepository journalRepository;
     private final JournalKeywordRepository journalKeywordRepository;
     private final DailyQuestionRepository dailyQuestionRepository;
-    private final QuestionAnswerKeywordRepository questionAnswerKeywordRepository;
 
     public MonthlyStatsResponseDto getMonthlyStats(Long userId, int year, int month) {
         long journalCount = journalRepository.countByUserIdAndMonth(userId, year, month);
@@ -34,18 +32,10 @@ public class StatsService {
     }
 
     private List<EmotionStatDto> buildEmotionDistribution(Long userId, int year, int month) {
-        // 저널 키워드와 질문 답변 키워드를 합산
         Map<String, Long> countMap = new LinkedHashMap<>();
 
         List<Object[]> journalStats = journalKeywordRepository.findMonthlyKeywordStats(userId, year, month);
         for (Object[] row : journalStats) {
-            String name = (String) row[0];
-            long count = (Long) row[1];
-            countMap.merge(name, count, Long::sum);
-        }
-
-        List<Object[]> answerStats = questionAnswerKeywordRepository.findMonthlyKeywordStats(userId, year, month);
-        for (Object[] row : answerStats) {
             String name = (String) row[0];
             long count = (Long) row[1];
             countMap.merge(name, count, Long::sum);


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #51 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- ML 서버 top-3 감정 score를 합이 1.0이 되도록 정규화
- 월별 감정 통계에서 질문 답변 키워드 집계 제거 (저널 키워드만 반영)

## 📸 테스트 증명 (필수)

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [ ] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [ ] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [ ] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [ ] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?