### PR TITLE
[FEAT] 회원탈퇴 api 구현

### DIFF
--- a/src/main/java/com/capstone/domain/clover/repository/CloverHistoryRepository.java
+++ b/src/main/java/com/capstone/domain/clover/repository/CloverHistoryRepository.java
@@ -1,0 +1,14 @@
+package com.capstone.domain.clover.repository;
+
+import com.capstone.domain.clover.entity.CloverHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CloverHistoryRepository extends JpaRepository<CloverHistory, Long> {
+
+  @Modifying
+  @Query("delete from CloverHistory ch where ch.user.id = :userId")
+  void deleteByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/capstone/domain/clover/repository/CloverHistoryRepository.java
+++ b/src/main/java/com/capstone/domain/clover/repository/CloverHistoryRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CloverHistoryRepository extends JpaRepository<CloverHistory, Long> {
 
   @Modifying

--- a/src/main/java/com/capstone/domain/journal/repository/JournalAnalysisRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalAnalysisRepository.java
@@ -3,7 +3,19 @@ package com.capstone.domain.journal.repository;
 import com.capstone.domain.journal.entity.JournalAnalysis;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JournalAnalysisRepository extends JpaRepository<JournalAnalysis, Long> {
   Optional<JournalAnalysis> findTopByJournalIdOrderByAnalyzedAtDesc(Long journalId);
+
+  @Modifying
+  @Query("""
+      delete from JournalAnalysis ja
+      where ja.journal.id in (
+          select j.id from Journal j where j.user.id = :userId
+      )
+      """)
+  void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/capstone/domain/journal/repository/JournalEmotionRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalEmotionRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface JournalEmotionRepository extends JpaRepository<JournalEmotion, Long> {
 
   @Modifying

--- a/src/main/java/com/capstone/domain/journal/repository/JournalEmotionRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalEmotionRepository.java
@@ -1,0 +1,21 @@
+package com.capstone.domain.journal.repository;
+
+import com.capstone.domain.journal.entity.JournalEmotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface JournalEmotionRepository extends JpaRepository<JournalEmotion, Long> {
+
+  @Modifying
+  @Query("""
+      delete from JournalEmotion je
+      where je.journalAnalysis.id in (
+          select ja.id from JournalAnalysis ja
+          join ja.journal j
+          where j.user.id = :userId
+      )
+      """)
+  void deleteByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/capstone/domain/journal/repository/JournalKeywordRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalKeywordRepository.java
@@ -2,12 +2,24 @@ package com.capstone.domain.journal.repository;
 
 import com.capstone.domain.journal.entity.JournalKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface JournalKeywordRepository extends JpaRepository<JournalKeyword, Long> {
+
+  @Modifying
+  @Query("""
+      delete from JournalKeyword jk
+      where jk.journalAnalysis.id in (
+          select ja.id from JournalAnalysis ja
+          join ja.journal j
+          where j.user.id = :userId
+      )
+      """)
+  void deleteByUserId(@Param("userId") Long userId);
 
   @Query("""
       select jk.keyword.name, count(jk.id), sum(jk.score)

--- a/src/main/java/com/capstone/domain/journal/repository/JournalReplyRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalReplyRepository.java
@@ -3,8 +3,20 @@ package com.capstone.domain.journal.repository;
 import com.capstone.domain.journal.entity.JournalReply;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JournalReplyRepository extends JpaRepository<JournalReply, Long> {
   Optional<JournalReply> findTopByJournalIdOrderByCreatedAtDesc(Long journalId);
   boolean existsByJournalId(Long journalId);
+
+  @Modifying
+  @Query("""
+      delete from JournalReply jr
+      where jr.journal.id in (
+          select j.id from Journal j where j.user.id = :userId
+      )
+      """)
+  void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/capstone/domain/journal/repository/JournalRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,4 +41,8 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
       @Param("year") int year,
       @Param("month") int month
   );
+
+  @Modifying
+  @Query("delete from Journal j where j.user.id = :userId")
+  void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/capstone/domain/question/repository/DailyQuestionRepository.java
+++ b/src/main/java/com/capstone/domain/question/repository/DailyQuestionRepository.java
@@ -2,6 +2,7 @@ package com.capstone.domain.question.repository;
 
 import com.capstone.domain.question.entity.DailyQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,4 +41,8 @@ public interface DailyQuestionRepository extends JpaRepository<DailyQuestion, Lo
             @Param("year") int year,
             @Param("month") int month
     );
+
+    @Modifying
+    @Query("delete from DailyQuestion dq where dq.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/capstone/domain/question/repository/QuestionAnswerKeywordRepository.java
+++ b/src/main/java/com/capstone/domain/question/repository/QuestionAnswerKeywordRepository.java
@@ -2,12 +2,24 @@ package com.capstone.domain.question.repository;
 
 import com.capstone.domain.question.entity.QuestionAnswerKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface QuestionAnswerKeywordRepository extends JpaRepository<QuestionAnswerKeyword, Long> {
+
+  @Modifying
+  @Query("""
+      delete from QuestionAnswerKeyword qak
+      where qak.questionAnswer.id in (
+          select qa.id from QuestionAnswer qa
+          join qa.dailyQuestion dq
+          where dq.user.id = :userId
+      )
+      """)
+  void deleteByUserId(@Param("userId") Long userId);
 
     @Query("""
             select qak.keyword.name, count(qak.id), sum(qak.score)

--- a/src/main/java/com/capstone/domain/question/repository/QuestionAnswerRepository.java
+++ b/src/main/java/com/capstone/domain/question/repository/QuestionAnswerRepository.java
@@ -2,8 +2,20 @@ package com.capstone.domain.question.repository;
 
 import com.capstone.domain.question.entity.QuestionAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer, Long> {
 
     boolean existsByDailyQuestionId(Long dailyQuestionId);
+
+    @Modifying
+    @Query("""
+        delete from QuestionAnswer qa
+        where qa.dailyQuestion.id in (
+            select dq.id from DailyQuestion dq where dq.user.id = :userId
+        )
+        """)
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/capstone/domain/user/controller/UserController.java
+++ b/src/main/java/com/capstone/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.capstone.domain.user.controller;
 
+import com.capstone.domain.user.dto.request.WithdrawRequestDto;
 import com.capstone.domain.user.dto.response.MyPageResponseDto;
 import com.capstone.domain.user.service.UserService;
 import com.capstone.global.common.ApiResponse;
@@ -7,6 +8,7 @@ import com.capstone.global.common.SuccessStatus;
 import com.capstone.global.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,5 +29,15 @@ public class UserController {
   ) {
     MyPageResponseDto response = userService.getMyPage(userPrincipal.getUserId());
     return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, response));
+  }
+
+  @Operation(summary = "회원 탈퇴")
+  @DeleteMapping("/me")
+  public ResponseEntity<ApiResponse<Void>> withdrawUser(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @Valid @RequestBody WithdrawRequestDto request
+  ) {
+    userService.withdrawUser(userPrincipal.getUserId(), request);
+    return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK));
   }
 }

--- a/src/main/java/com/capstone/domain/user/dto/request/WithdrawRequestDto.java
+++ b/src/main/java/com/capstone/domain/user/dto/request/WithdrawRequestDto.java
@@ -1,0 +1,7 @@
+package com.capstone.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawRequestDto(
+    @NotBlank String password
+) {}

--- a/src/main/java/com/capstone/domain/user/service/UserService.java
+++ b/src/main/java/com/capstone/domain/user/service/UserService.java
@@ -20,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -77,9 +79,15 @@ public class UserService {
     questionAnswerRepository.deleteByUserId(userId);
     dailyQuestionRepository.deleteByUserId(userId);
 
-    refreshTokenRepository.deleteById(userId);
-
     userRepository.deleteById(userId);
+
+    // DB 커밋 성공 이후에 Redis 삭제 — 커밋 전 삭제 시 DB 롤백돼도 토큰이 사라지는 불일치 방지
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+      @Override
+      public void afterCommit() {
+        refreshTokenRepository.deleteById(userId);
+      }
+    });
   }
 
   private String resolveCloverComment(Long clover) {

--- a/src/main/java/com/capstone/domain/user/service/UserService.java
+++ b/src/main/java/com/capstone/domain/user/service/UserService.java
@@ -1,11 +1,23 @@
 package com.capstone.domain.user.service;
 
+import com.capstone.domain.auth.repository.RefreshTokenRepository;
+import com.capstone.domain.clover.repository.CloverHistoryRepository;
+import com.capstone.domain.journal.repository.JournalAnalysisRepository;
+import com.capstone.domain.journal.repository.JournalEmotionRepository;
+import com.capstone.domain.journal.repository.JournalKeywordRepository;
+import com.capstone.domain.journal.repository.JournalReplyRepository;
+import com.capstone.domain.journal.repository.JournalRepository;
+import com.capstone.domain.question.repository.DailyQuestionRepository;
+import com.capstone.domain.question.repository.QuestionAnswerKeywordRepository;
+import com.capstone.domain.question.repository.QuestionAnswerRepository;
+import com.capstone.domain.user.dto.request.WithdrawRequestDto;
 import com.capstone.domain.user.dto.response.MyPageResponseDto;
 import com.capstone.domain.user.entity.User;
 import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.error.BusinessException;
 import com.capstone.global.error.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +27,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JournalEmotionRepository journalEmotionRepository;
+  private final JournalKeywordRepository journalKeywordRepository;
+  private final JournalAnalysisRepository journalAnalysisRepository;
+  private final JournalReplyRepository journalReplyRepository;
+  private final JournalRepository journalRepository;
+  private final CloverHistoryRepository cloverHistoryRepository;
+  private final QuestionAnswerKeywordRepository questionAnswerKeywordRepository;
+  private final QuestionAnswerRepository questionAnswerRepository;
+  private final DailyQuestionRepository dailyQuestionRepository;
 
   public User getUserById(Long userId) {
     return userRepository.findById(userId)
@@ -31,6 +54,32 @@ public class UserService {
         user.getCloverBalance(),
         resolveCloverComment(user.getCloverBalance())
     );
+  }
+
+  @Transactional
+  public void withdrawUser(Long userId, WithdrawRequestDto request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
+
+    if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+      throw new BusinessException(ErrorStatus.INVALID_PASSWORD);
+    }
+
+    journalEmotionRepository.deleteByUserId(userId);
+    journalKeywordRepository.deleteByUserId(userId);
+    journalAnalysisRepository.deleteByUserId(userId);
+    journalReplyRepository.deleteByUserId(userId);
+    journalRepository.deleteByUserId(userId);
+
+    cloverHistoryRepository.deleteByUserId(userId);
+
+    questionAnswerKeywordRepository.deleteByUserId(userId);
+    questionAnswerRepository.deleteByUserId(userId);
+    dailyQuestionRepository.deleteByUserId(userId);
+
+    refreshTokenRepository.deleteById(userId);
+
+    userRepository.deleteById(userId);
   }
 
   private String resolveCloverComment(Long clover) {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #53 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- `DELETE /api/v1/users/me` 회원탈퇴 API 추가
- 비밀번호 검증 후 유저 및 관련 데이터 전체 삭제 처리
- 탈퇴 시 삭제 대상: 저널(감정/키워드/분석/답장), 클로버 내역, 질문 답변, Redis 리프레시 토큰

## 📸 테스트 증명 (필수)

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [ ] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [ ] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [ ] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [ ] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* 사용자 계정 탈퇴 기능이 추가되었습니다. 회원 탈퇴 시 사용자 데이터는 안전하게 삭제됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/4-1-Capstone-Design/CAPSTONE-SERVER/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->